### PR TITLE
Fix Sized Scroll Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,7 @@
 
 ## 0.2.8
 * fix display no items widget
+
+
+## 0.3.5
+* fix display no items widget

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ void dispose() {
 
 @override
 Widget build(BuildContext context) {
-  return AnimatedInfiniteScrollView<User>.builder(
+  return AnimatedInfiniteScrollView<User>(
       viewModel: viewModel,
       loadingWidget: const AppProgressBar(), // customize your loading widget
       footerLoadingWidget: const AppProgressBar(), // customize your pagination loading widget
       errorWidget: const Text("Pagination Error"), // customize your error widget
-      builder: (context, index, item) => UserCard(user: item, onDelete: deleteUser),
+      itemBuilder: (index, item) => UserCard(user: item, onDelete: deleteUser),
       refreshIndicator: true,
       onRefresh: () {
         // handle swipe refresh event
@@ -134,8 +134,7 @@ Widget build(BuildContext context) {
 ```
 ## **AnimatedInfiniteScrollView** Parameters:
 * **viewModel**: The View-Model you declared above in this example *(required)*.
-* **topWidget**: a widget you want to place at the top of the first **builder** widget *(optional)*.
-* **fixedTopWidget**: Control the position of the top widget i.e. fixed at the top or move with the scroll *(optional)*.
+* **topWidget**: a widget you want to place at the top of the first **itemBuilder** widget *(optional)*.
 * **loadingWidget**: a widget you want to display when first page is loading *(optional)*.
 * **footerLoadingWidget**: a widget you want to display when pagination data is loading *(optional)*.
 * **errorWidget**: a widget you want to display when pagination data  is field loading (throw exception) *(optional)*.

--- a/example/lib/ui/widgets/users_list_view.dart
+++ b/example/lib/ui/widgets/users_list_view.dart
@@ -37,7 +37,7 @@ class _UsersListViewState extends State<UsersListView> {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedInfiniteScrollView<User>.builder(
+    return AnimatedInfiniteScrollView<User>(
       viewModel: viewModel,
       loadingWidget: const Center(
         child: SizedBox(
@@ -51,7 +51,7 @@ class _UsersListViewState extends State<UsersListView> {
       // customize your pagination loading widget
       errorWidget: const Text("Pagination Error"),
       // customize your error widget
-      builder: (context, index, item) => UserCard(user: item, onDelete: deleteUser),
+      itemBuilder: (index, item) => UserCard(user: item, onDelete: deleteUser),
       refreshIndicator: true,
     );
   }

--- a/example/lib/ui/widgets/users_list_view.dart
+++ b/example/lib/ui/widgets/users_list_view.dart
@@ -51,7 +51,7 @@ class _UsersListViewState extends State<UsersListView> {
       // customize your pagination loading widget
       errorWidget: const Text("Pagination Error"),
       // customize your error widget
-      itemBuilder: (index, item) => UserCard(user: item, onDelete: deleteUser),
+      itemBuilder: (context, index, item) => UserCard(user: item, onDelete: deleteUser),
       refreshIndicator: true,
     );
   }

--- a/lib/animated_infinite_scroll_pagination.dart
+++ b/lib/animated_infinite_scroll_pagination.dart
@@ -1,8 +1,7 @@
 library animated_infinite_scroll_pagination;
 
-export 'src/models/base_query.dart';
-export 'src/models/pagination_model.dart';
 export 'src/models/response_state.dart';
-export 'src/ui/core/animated_infinite_scroll.dart';
-export 'src/viewmodels/pagination_params.dart';
 export 'src/viewmodels/pagination_viewmodel.dart';
+export 'src/ui/core/animated_infinite_scroll.dart';
+export 'src/models/pagination_model.dart';
+export 'src/viewmodels/pagination_params.dart';

--- a/lib/src/configuration/configuration.dart
+++ b/lib/src/configuration/configuration.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 class AnimatedPaginationConfiguration<T extends Object> {
   final PaginationViewModel<T> viewModel;
   final ScrollPhysics? physics;
-  final Widget Function(int index, T item)? itemBuilder;
+  final Widget Function(BuildContext context, int index, T item)? itemBuilder;
   final Widget? topWidget;
   final Widget? loadingWidget;
   final Widget? errorWidget;
@@ -12,7 +12,7 @@ class AnimatedPaginationConfiguration<T extends Object> {
   final Widget? noItemsWidget;
   final Axis scrollDirection;
   final SliverGridDelegate? gridDelegate;
-  final Widget Function(List<PaginationModel<T>>)? child;
+  final Widget Function(BuildContext context, List<PaginationModel<T>>)? child;
   final EdgeInsets? padding;
   final bool? spawnIsolate;
 

--- a/lib/src/configuration/configuration.dart
+++ b/lib/src/configuration/configuration.dart
@@ -4,9 +4,7 @@ import 'package:flutter/material.dart';
 class AnimatedPaginationConfiguration<T extends Object> {
   final PaginationViewModel<T> viewModel;
   final ScrollPhysics? physics;
-  final Widget Function(BuildContext context, int index, T item)? itemBuilder;
-  final Widget Function(BuildContext context, int index, T item)?
-      separatorBuilder;
+  final Widget Function(int index, T item)? itemBuilder;
   final Widget? topWidget;
   final Widget? loadingWidget;
   final Widget? errorWidget;
@@ -17,28 +15,20 @@ class AnimatedPaginationConfiguration<T extends Object> {
   final Widget Function(List<PaginationModel<T>>)? child;
   final EdgeInsets? padding;
   final bool? spawnIsolate;
-  final bool? fixedTopWidget;
 
-  AnimatedPaginationConfiguration({
+  const AnimatedPaginationConfiguration({
     required this.viewModel,
     required this.itemBuilder,
-    required this.scrollDirection,
-    required this.gridDelegate,
-    required this.child,
     required this.topWidget,
     required this.footerLoadingWidget,
     required this.loadingWidget,
     required this.errorWidget,
     required this.physics,
+    required this.scrollDirection,
+    required this.gridDelegate,
     required this.noItemsWidget,
+    required this.child,
     required this.padding,
     required this.spawnIsolate,
-    required this.separatorBuilder,
-    required this.fixedTopWidget,
-  }) {
-    assert((child != null || itemBuilder != null) &&
-        !(child != null && itemBuilder != null));
-    assert((topWidget == null && fixedTopWidget == null) ||
-        (topWidget != null && fixedTopWidget != null));
-  }
+  });
 }

--- a/lib/src/models/base_query.dart
+++ b/lib/src/models/base_query.dart
@@ -1,5 +1,0 @@
-class AbstractQueryParameters {
-  const AbstractQueryParameters();
-
-  Map<String, String> getValue() => {};
-}

--- a/lib/src/models/pagination_model.dart
+++ b/lib/src/models/pagination_model.dart
@@ -1,7 +1,7 @@
-import 'package:equatable/equatable.dart';
 import 'package:uuid/uuid.dart';
+import 'package:equatable/equatable.dart';
 
-class PaginationModel<T> extends Equatable {
+class PaginationModel<T extends Object> extends Equatable {
   final String id;
   final T item;
   final int page;

--- a/lib/src/ui/core/animated_infinite_scroll.dart
+++ b/lib/src/ui/core/animated_infinite_scroll.dart
@@ -1,7 +1,6 @@
 import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 import 'package:animated_infinite_scroll_pagination/src/configuration/configuration.dart';
 import 'package:flutter/material.dart';
-
 import 'animated_pagination_scrollview.dart';
 
 class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
@@ -12,11 +11,7 @@ class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
   final ScrollPhysics? physics;
 
   /// builder of each item in list.
-  final Widget Function(BuildContext context, int index, T item)? itemBuilder;
-
-  /// builder of items separator in list.
-  final Widget Function(BuildContext context, int index, T item)?
-      separatorBuilder;
+  final Widget Function(int index, T item)? itemBuilder;
 
   /// pass [topWidget] when you want to place a widget at the top of the first [itemBuilder] widget.
   final Widget? topWidget;
@@ -47,7 +42,7 @@ class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
   final SliverGridDelegate? gridDelegate;
 
   /// Custom [Widget] inside [AnimatedPaginationScrollView]
-  final Widget Function(List<PaginationModel<T>>)? childBuilder;
+  final Widget Function(List<PaginationModel<T>>)? child;
 
   /// scroll-view padding
   final EdgeInsets? padding;
@@ -59,12 +54,9 @@ class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
   /// optimal performance.
   final bool? spawnIsolate;
 
-  final bool? fixedTopWidget;
-
-  const AnimatedInfiniteScrollView.builder({
+  const AnimatedInfiniteScrollView({
     required this.viewModel,
-    required final Widget Function(BuildContext context, int index, T item)
-        builder,
+    this.itemBuilder,
     this.topWidget,
     this.footerLoadingWidget,
     this.loadingWidget,
@@ -75,52 +67,23 @@ class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
     this.onRefresh,
     this.scrollDirection = Axis.vertical,
     this.gridDelegate,
+    this.child,
     this.padding,
     this.spawnIsolate,
     Key? key,
-    this.separatorBuilder,
-    this.fixedTopWidget,
-  })  : childBuilder = null,
-        itemBuilder = builder,
-        super(key: key);
-
-  const AnimatedInfiniteScrollView.child({
-    required this.viewModel,
-    required Widget Function(List<PaginationModel<T>>) builder,
-    this.topWidget,
-    this.footerLoadingWidget,
-    this.loadingWidget,
-    this.errorWidget,
-    this.noItemsWidget,
-    this.physics,
-    this.refreshIndicator = false,
-    this.onRefresh,
-    this.scrollDirection = Axis.vertical,
-    this.gridDelegate,
-    this.padding,
-    this.spawnIsolate,
-    Key? key,
-    this.separatorBuilder,
-    this.fixedTopWidget,
-  })  : itemBuilder = null,
-        childBuilder = builder,
-        super(key: key);
+  }) : super(key: key);
 
   @override
-  State<AnimatedInfiniteScrollView<T>> createState() =>
-      _AnimatedInfiniteScrollViewState<T>();
+  State<AnimatedInfiniteScrollView<T>> createState() => _AnimatedInfiniteScrollViewState<T>();
 }
 
-class _AnimatedInfiniteScrollViewState<T extends Object>
-    extends State<AnimatedInfiniteScrollView<T>> {
-  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
-      GlobalKey<RefreshIndicatorState>();
+class _AnimatedInfiniteScrollViewState<T extends Object> extends State<AnimatedInfiniteScrollView<T>> {
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey<RefreshIndicatorState>();
 
-  AnimatedPaginationConfiguration<T> get configuration =>
-      AnimatedPaginationConfiguration(
+  AnimatedPaginationConfiguration<T> get configuration => AnimatedPaginationConfiguration(
         viewModel: widget.viewModel,
         itemBuilder: widget.itemBuilder,
-        child: widget.childBuilder,
+        child: widget.child,
         errorWidget: widget.errorWidget,
         footerLoadingWidget: widget.footerLoadingWidget,
         gridDelegate: widget.gridDelegate,
@@ -131,9 +94,6 @@ class _AnimatedInfiniteScrollViewState<T extends Object>
         topWidget: widget.topWidget,
         padding: widget.padding,
         spawnIsolate: widget.spawnIsolate,
-        separatorBuilder: null,
-        fixedTopWidget:
-            widget.topWidget == null ? null : widget.fixedTopWidget ?? false,
       );
 
   Future<void> _onRefresh() async {
@@ -149,10 +109,8 @@ class _AnimatedInfiniteScrollViewState<T extends Object>
     return NotificationListener<ScrollNotification>(
       key: UniqueKey(),
       onNotification: (scrollNotification) {
-        if (scrollNotification.metrics.pixels ==
-            scrollNotification.metrics.maxScrollExtent) {
-          if (widget.viewModel.paginationParams.page > 1 &&
-              widget.viewModel.paginationParams.total == 0) {
+        if (scrollNotification.metrics.pixels == scrollNotification.metrics.maxScrollExtent) {
+          if (widget.viewModel.paginationParams.page > 1 && widget.viewModel.paginationParams.total == 0) {
             // do nothing
           } else {
             widget.viewModel.getPaginationList();
@@ -163,8 +121,8 @@ class _AnimatedInfiniteScrollViewState<T extends Object>
       child: widget.refreshIndicator
           ? RefreshIndicator(
               key: _refreshIndicatorKey,
-              onRefresh: _onRefresh,
               child: AnimatedPaginationScrollView(configuration),
+              onRefresh: _onRefresh,
             )
           : AnimatedPaginationScrollView(configuration),
     );

--- a/lib/src/ui/core/animated_infinite_scroll.dart
+++ b/lib/src/ui/core/animated_infinite_scroll.dart
@@ -11,7 +11,7 @@ class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
   final ScrollPhysics? physics;
 
   /// builder of each item in list.
-  final Widget Function(int index, T item)? itemBuilder;
+  final Widget Function(BuildContext context, int index, T item)? itemBuilder;
 
   /// pass [topWidget] when you want to place a widget at the top of the first [itemBuilder] widget.
   final Widget? topWidget;
@@ -42,7 +42,7 @@ class AnimatedInfiniteScrollView<T extends Object> extends StatefulWidget {
   final SliverGridDelegate? gridDelegate;
 
   /// Custom [Widget] inside [AnimatedPaginationScrollView]
-  final Widget Function(List<PaginationModel<T>>)? child;
+  final Widget Function(BuildContext context, List<PaginationModel<T>>)? child;
 
   /// scroll-view padding
   final EdgeInsets? padding;

--- a/lib/src/ui/core/animated_pagination_scrollview.dart
+++ b/lib/src/ui/core/animated_pagination_scrollview.dart
@@ -1,27 +1,24 @@
 import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 import 'package:animated_infinite_scroll_pagination/src/ui/list/pagination_animated_grid_widget.dart';
 import 'package:animated_infinite_scroll_pagination/src/ui/list/pagination_animated_list_widget.dart';
+import 'package:animated_infinite_scroll_pagination/src/ui/widgets/full_size_scrollview.dart';
+import 'package:animated_infinite_scroll_pagination/src/ui/widgets/pagination_footer_loader_widget.dart';
 import 'package:animated_infinite_scroll_pagination/src/ui/widgets/pagination_loader_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx_live_data/flutterx_live_data.dart';
-
 import '../../configuration/configuration.dart';
-import '../widgets/pagination_footer_loader_widget.dart';
 import '../widgets/state_widget.dart';
 
 class AnimatedPaginationScrollView<T extends Object> extends StatefulWidget {
   final AnimatedPaginationConfiguration<T> configuration;
 
-  const AnimatedPaginationScrollView(this.configuration, {Key? key})
-      : super(key: key);
+  const AnimatedPaginationScrollView(this.configuration, {Key? key}) : super(key: key);
 
   @override
-  State<AnimatedPaginationScrollView<T>> createState() =>
-      _AnimatedPaginationScrollViewState<T>();
+  State<AnimatedPaginationScrollView<T>> createState() => _AnimatedPaginationScrollViewState<T>();
 }
 
-class _AnimatedPaginationScrollViewState<T extends Object>
-    extends State<AnimatedPaginationScrollView<T>> {
+class _AnimatedPaginationScrollViewState<T extends Object> extends State<AnimatedPaginationScrollView<T>> {
   AnimatedPaginationConfiguration<T> get configuration => widget.configuration;
 
   Widget builder({
@@ -35,82 +32,38 @@ class _AnimatedPaginationScrollViewState<T extends Object>
     }
   }
 
-  Widget buildScrollLayout(BuildContext context, bool loading,
-          bool noItemsFound, bool error, bool idle) =>
-      builder(
-        mainAxisAlignment:
-            idle ? MainAxisAlignment.spaceBetween : MainAxisAlignment.start,
-        children: [
-          Builder(
-            builder: (context) {
-              final hasCenteredState = error || noItemsFound;
-              if (idle) {
-                return Expanded(child: PaginationLoaderWidget(configuration));
-              } else if (configuration.child != null) {
-                if (!hasCenteredState) {
-                  return Expanded(
-                    child: LiveDataBuilder<List<PaginationModel<T>>>(
-                      data: configuration.viewModel.paginationParams.itemsList,
-                      builder: (context, items) => configuration.child!(items),
-                    ),
-                  );
-                }
-              } else if (configuration.gridDelegate != null) {
-                if (!hasCenteredState) {
-                  return Expanded(
-                      child: PaginationAnimatedGridWidget(configuration));
-                }
-              } else {
-                if (!hasCenteredState) {
-                  return Expanded(
-                      child: PaginationAnimatedListWidget(configuration));
-                }
-              }
-              return const SizedBox.shrink();
-            },
-          ),
-          if (!idle)
-            StateWidget(
-              configuration,
-              noItemsFound: noItemsFound,
-              loading: loading,
-              error: error,
-            ),
-          PaginationFooterLoaderWidget(configuration),
-        ],
-      );
-
   @override
   Widget build(BuildContext context) {
-    return MultipleLiveDataBuilder.with4<bool, bool, bool, bool>(
-      x1: configuration.viewModel.paginationParams.loading,
-      x2: configuration.viewModel.paginationParams.noItemsFound,
-      x3: configuration.viewModel.paginationParams.error,
-      x4: configuration.viewModel.paginationParams.idle,
-      builder: (context, loading, noItemsFound, error, idle) =>
-          ((!(configuration.fixedTopWidget ?? false) &&
-                      configuration.topWidget != null) ||
-                  configuration.topWidget == null)
-              ? CustomScrollView(
-                  scrollDirection: configuration.scrollDirection,
-                  physics: widget.configuration.physics,
-                  slivers: [
-                    SliverToBoxAdapter(child: configuration.topWidget),
-                    SliverFillRemaining(
-                      child: buildScrollLayout(
-                          context, loading, noItemsFound, error, idle),
-                    )
-                  ],
-                )
-              : builder(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    configuration.topWidget!,
-                    Expanded(
-                        child: buildScrollLayout(
-                            context, loading, noItemsFound, error, idle))
-                  ],
-                ),
+    return FullSizeScrollView(
+      configuration: configuration,
+      child: LiveDataBuilder<bool>(
+        data: configuration.viewModel.paginationParams.idle,
+        builder: (context, idle) => builder(
+          mainAxisAlignment: idle ? MainAxisAlignment.spaceBetween : MainAxisAlignment.start,
+          children: [
+            configuration.topWidget ?? const SizedBox(),
+            Builder(
+              builder: (context) {
+                if (idle) {
+                  return PaginationLoaderWidget(configuration);
+                } else if (configuration.child != null) {
+                  return LiveDataBuilder<List<PaginationModel<T>>>(
+                    data: configuration.viewModel.paginationParams.itemsList,
+                    builder: (context, items) => configuration.child!(items),
+                  );
+                } else if (configuration.gridDelegate != null) {
+                  return PaginationAnimatedGridWidget(configuration);
+                } else {
+                  return PaginationAnimatedListWidget(configuration);
+                }
+              },
+            ),
+            if (!idle) StateWidget(configuration),
+            PaginationFooterLoaderWidget(configuration),
+            if (idle) const SizedBox(),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/ui/core/animated_pagination_scrollview.dart
+++ b/lib/src/ui/core/animated_pagination_scrollview.dart
@@ -49,7 +49,7 @@ class _AnimatedPaginationScrollViewState<T extends Object> extends State<Animate
                 } else if (configuration.child != null) {
                   return LiveDataBuilder<List<PaginationModel<T>>>(
                     data: configuration.viewModel.paginationParams.itemsList,
-                    builder: (context, items) => configuration.child!(items),
+                    builder: (context, items) => configuration.child!(context, items),
                   );
                 } else if (configuration.gridDelegate != null) {
                   return PaginationAnimatedGridWidget(configuration);

--- a/lib/src/ui/list/pagination_animated_grid_widget.dart
+++ b/lib/src/ui/list/pagination_animated_grid_widget.dart
@@ -1,22 +1,18 @@
-import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx_live_data/flutterx_live_data.dart';
-
 import '../../configuration/configuration.dart';
+import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 
 class PaginationAnimatedGridWidget<T extends Object> extends StatefulWidget {
   final AnimatedPaginationConfiguration<T> configuration;
 
-  const PaginationAnimatedGridWidget(this.configuration, {Key? key})
-      : super(key: key);
+  const PaginationAnimatedGridWidget(this.configuration, {Key? key}) : super(key: key);
 
   @override
-  State<PaginationAnimatedGridWidget<T>> createState() =>
-      _PaginationAnimatedGridWidgetState<T>();
+  State<PaginationAnimatedGridWidget<T>> createState() => _PaginationAnimatedGridWidgetState<T>();
 }
 
-class _PaginationAnimatedGridWidgetState<T extends Object>
-    extends State<PaginationAnimatedGridWidget<T>> {
+class _PaginationAnimatedGridWidgetState<T extends Object> extends State<PaginationAnimatedGridWidget<T>> {
   PaginationViewModel<T> get viewModel => widget.configuration.viewModel;
 
   @override
@@ -26,14 +22,12 @@ class _PaginationAnimatedGridWidgetState<T extends Object>
       builder: (context, list) => GridView.builder(
         key: const Key("itemsList"),
         gridDelegate: widget.configuration.gridDelegate!,
-        physics: widget.configuration.topWidget == null
-            ? widget.configuration.physics
-            : const NeverScrollableScrollPhysics(),
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
         itemCount: list.length,
         scrollDirection: widget.configuration.scrollDirection,
         itemBuilder: (context, index) {
-          return widget.configuration.itemBuilder
-              ?.call(context, index, list[index].item);
+          return widget.configuration.itemBuilder?.call(index, list[index].item);
         },
       ),
     );

--- a/lib/src/ui/list/pagination_animated_grid_widget.dart
+++ b/lib/src/ui/list/pagination_animated_grid_widget.dart
@@ -27,7 +27,7 @@ class _PaginationAnimatedGridWidgetState<T extends Object> extends State<Paginat
         itemCount: list.length,
         scrollDirection: widget.configuration.scrollDirection,
         itemBuilder: (context, index) {
-          return widget.configuration.itemBuilder?.call(index, list[index].item);
+          return widget.configuration.itemBuilder?.call(context, index, list[index].item);
         },
       ),
     );

--- a/lib/src/ui/list/pagination_animated_list_widget.dart
+++ b/lib/src/ui/list/pagination_animated_list_widget.dart
@@ -1,46 +1,21 @@
-import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx_live_data/flutterx_live_data.dart';
 import 'package:implicitly_animated_reorderable_list_2/implicitly_animated_reorderable_list_2.dart';
 import 'package:implicitly_animated_reorderable_list_2/transitions.dart';
-
 import '../../configuration/configuration.dart';
+import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 
 class PaginationAnimatedListWidget<T extends Object> extends StatefulWidget {
   final AnimatedPaginationConfiguration<T> configuration;
 
-  const PaginationAnimatedListWidget(this.configuration, {Key? key})
-      : super(key: key);
+  const PaginationAnimatedListWidget(this.configuration, {Key? key}) : super(key: key);
 
   @override
-  State<PaginationAnimatedListWidget<T>> createState() =>
-      _PaginationAnimatedListWidgetState<T>();
+  State<PaginationAnimatedListWidget<T>> createState() => _PaginationAnimatedListWidgetState<T>();
 }
 
-class _PaginationAnimatedListWidgetState<T extends Object>
-    extends State<PaginationAnimatedListWidget<T>> {
+class _PaginationAnimatedListWidgetState<T extends Object> extends State<PaginationAnimatedListWidget<T>> {
   PaginationViewModel<T> get viewModel => widget.configuration.viewModel;
-
-  Widget itemBuilder(BuildContext context, int index, T item) {
-    if (widget.configuration.separatorBuilder == null) {
-      return widget.configuration.itemBuilder!(context, index, item);
-    }
-    if (widget.configuration.scrollDirection == Axis.horizontal) {
-      return Row(
-        children: [
-          widget.configuration.itemBuilder!(context, index, item),
-          widget.configuration.separatorBuilder!(context, index, item),
-        ],
-      );
-    }
-    return Column(
-      children: [
-        widget.configuration.itemBuilder!(context, index, item),
-        widget.configuration.separatorBuilder!(context, index, item),
-      ],
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return LiveDataBuilder<List<PaginationModel<T>>>(
@@ -48,27 +23,22 @@ class _PaginationAnimatedListWidgetState<T extends Object>
       builder: (context, list) => list.isEmpty
           ? const SizedBox()
           : ImplicitlyAnimatedList<PaginationModel<T>>(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
               spawnIsolate: widget.configuration.spawnIsolate,
               items: list,
-              physics: widget.configuration.topWidget == null
-                  ? widget.configuration.physics
-                  : const NeverScrollableScrollPhysics(),
               scrollDirection: widget.configuration.scrollDirection,
-              areItemsTheSame: (a, b) => widget.configuration.viewModel
-                  .areItemsTheSame(a.item, b.item),
-              itemBuilder: (context, animation, item, index) =>
-                  SizeFadeTransition(
+              areItemsTheSame: (a, b) => widget.configuration.viewModel.areItemsTheSame(a.item, b.item),
+              itemBuilder: (context, animation, item, i) => SizeFadeTransition(
                 key: ObjectKey(item),
                 animation: animation,
-                child: itemBuilder(context, index, item.item),
+                child: widget.configuration.itemBuilder?.call(i, item.item),
               ),
-              updateItemBuilder: (context, animation, model) {
-                final index = list.indexWhere((value) => widget
-                    .configuration.viewModel
-                    .areItemsTheSame(value.item, model.item));
+              updateItemBuilder: (context, animation, item) {
+                final index = list.indexOf(item);
                 return FadeTransition(
                   opacity: animation,
-                  child: itemBuilder(context, index, model.item),
+                  child: widget.configuration.itemBuilder?.call(index, item.item),
                 );
               },
             ),

--- a/lib/src/ui/list/pagination_animated_list_widget.dart
+++ b/lib/src/ui/list/pagination_animated_list_widget.dart
@@ -32,13 +32,13 @@ class _PaginationAnimatedListWidgetState<T extends Object> extends State<Paginat
               itemBuilder: (context, animation, item, i) => SizeFadeTransition(
                 key: ObjectKey(item),
                 animation: animation,
-                child: widget.configuration.itemBuilder?.call(i, item.item),
+                child: widget.configuration.itemBuilder?.call(context, i, item.item),
               ),
               updateItemBuilder: (context, animation, item) {
                 final index = list.indexOf(item);
                 return FadeTransition(
                   opacity: animation,
-                  child: widget.configuration.itemBuilder?.call(index, item.item),
+                  child: widget.configuration.itemBuilder?.call(context, index, item.item),
                 );
               },
             ),

--- a/lib/src/ui/widgets/full_size_scrollview.dart
+++ b/lib/src/ui/widgets/full_size_scrollview.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import '../../configuration/configuration.dart';
 
 class FullSizeScrollView<T extends Object> extends StatelessWidget {
@@ -17,17 +16,14 @@ class FullSizeScrollView<T extends Object> extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraint) {
         return SingleChildScrollView(
-          physics:
-              configuration.physics ?? const AlwaysScrollableScrollPhysics(),
+          physics: configuration.physics ?? const AlwaysScrollableScrollPhysics(),
           scrollDirection: configuration.scrollDirection,
           padding: configuration.padding,
           child: ConstrainedBox(
             // expand child
             constraints: BoxConstraints(
               minHeight: constraint.maxHeight,
-              minWidth: configuration.scrollDirection == Axis.horizontal
-                  ? constraint.maxWidth
-                  : double.infinity,
+              minWidth: configuration.scrollDirection == Axis.horizontal ? constraint.maxWidth : double.infinity,
             ),
             child: child,
           ),

--- a/lib/src/ui/widgets/no_items_widget.dart
+++ b/lib/src/ui/widgets/no_items_widget.dart
@@ -11,8 +11,10 @@ class NoItemsWidget<T extends Object> extends StatelessWidget {
   Widget build(BuildContext context) {
     return LiveDataBuilder<bool>(
       data: configuration.viewModel.paginationParams.noItemsFound,
-      builder: (context, value) => Visibility(
-          visible: value, child: Center(child: configuration.noItemsWidget)),
+      builder: (context, value) {
+        if (value) return Center(child: configuration.noItemsWidget);
+        return const SizedBox();
+      },
     );
   }
 }

--- a/lib/src/ui/widgets/pagination_error_widget.dart
+++ b/lib/src/ui/widgets/pagination_error_widget.dart
@@ -14,10 +14,12 @@ class PaginationErrorWidget<T extends Object> extends StatelessWidget {
       child: Center(
         child: LiveDataBuilder<bool>(
           data: configuration.viewModel.paginationParams.error,
-          builder: (context, error) => Visibility(
-            visible: error,
-            child: configuration.errorWidget ?? const SizedBox.shrink(),
-          ),
+          builder: (context, error) {
+            if (error) {
+              return configuration.errorWidget ?? const SizedBox();
+            }
+            return const SizedBox.shrink();
+          },
         ),
       ),
     );

--- a/lib/src/ui/widgets/pagination_footer_loader_widget.dart
+++ b/lib/src/ui/widgets/pagination_footer_loader_widget.dart
@@ -1,38 +1,32 @@
 import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx_live_data/flutterx_live_data.dart';
-
-import '../../configuration/configuration.dart';
 import 'app_progress_bar.dart';
+import '../../configuration/configuration.dart';
 
 class PaginationFooterLoaderWidget<T extends Object> extends StatelessWidget {
   final AnimatedPaginationConfiguration<T> configuration;
 
-  const PaginationFooterLoaderWidget(this.configuration, {Key? key})
-      : super(key: key);
+  const PaginationFooterLoaderWidget(this.configuration, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MultipleLiveDataBuilder.with2<bool, List<PaginationModel>>(
       x1: configuration.viewModel.paginationParams.loading,
       x2: configuration.viewModel.paginationParams.itemsList,
-      builder: (context, loading, itemsList) => AnimatedCrossFade(
-        duration: const Duration(milliseconds: 100),
-        crossFadeState: loading && itemsList.isNotEmpty
-            ? CrossFadeState.showFirst
-            : CrossFadeState.showSecond,
-        firstChild: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Center(
-            child: configuration.footerLoadingWidget ?? const AppProgressBar(),
-          ),
-        ),
-        secondChild: SizedBox(
-            height: configuration.viewModel.paginationParams.lastPage ||
-                    itemsList.isEmpty
-                ? 0.0
-                : 70.0),
-      ),
+      builder: (context, loading, itemsList) {
+        if (loading && itemsList.isNotEmpty) {
+          return Padding(
+            padding: const EdgeInsets.all(12),
+            child: Center(
+              child: configuration.footerLoadingWidget ?? const AppProgressBar(),
+            ),
+          );
+        } else {
+          final size = configuration.viewModel.paginationParams.lastPage || itemsList.isEmpty ? 0.0 : 70.0;
+          return SizedBox(height: size);
+        }
+      },
     );
   }
 }

--- a/lib/src/ui/widgets/pagination_loader_widget.dart
+++ b/lib/src/ui/widgets/pagination_loader_widget.dart
@@ -1,26 +1,23 @@
 import 'package:animated_infinite_scroll_pagination/src/configuration/configuration.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx_live_data/flutterx_live_data.dart';
-
 import 'app_progress_bar.dart';
 
 class PaginationLoaderWidget<T extends Object> extends StatelessWidget {
   final AnimatedPaginationConfiguration<T> configuration;
 
-  const PaginationLoaderWidget(this.configuration, {Key? key})
-      : super(key: key);
+  const PaginationLoaderWidget(this.configuration, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return LiveDataBuilder<bool>(
       data: configuration.viewModel.paginationParams.loading,
-      builder: (context, loading) => Visibility(
-        visible: loading &&
-            configuration.viewModel.paginationParams.total == 0 &&
-            configuration.viewModel.paginationParams.page == 1,
-        child: configuration.loadingWidget ??
-            const Center(child: AppProgressBar()),
-      ),
+      builder: (context, loading) {
+        if (loading && configuration.viewModel.paginationParams.total == 0 && configuration.viewModel.paginationParams.page == 1) {
+          return configuration.loadingWidget ?? const Center(child: AppProgressBar());
+        }
+        return const SizedBox();
+      },
     );
   }
 }

--- a/lib/src/ui/widgets/state_widget.dart
+++ b/lib/src/ui/widgets/state_widget.dart
@@ -1,36 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutterx_live_data/flutterx_live_data.dart';
 
 import '../../configuration/configuration.dart';
 import 'app_progress_bar.dart';
 
 class StateWidget<T extends Object> extends StatelessWidget {
   final AnimatedPaginationConfiguration<T> configuration;
-  final bool loading;
-  final bool noItemsFound;
-  final bool error;
-
-  const StateWidget(this.configuration,
-      {Key? key,
-      required this.loading,
-      required this.noItemsFound,
-      required this.error})
-      : super(key: key);
+  const StateWidget(this.configuration, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    if (loading &&
-        configuration.viewModel.paginationParams.total == 0 &&
-        configuration.viewModel.paginationParams.page == 1) {
-      return configuration.loadingWidget ??
-          const Center(child: AppProgressBar());
-    }
-    if (error) {
-      return Expanded(
-          child: configuration.errorWidget ?? const SizedBox.shrink());
-    }
-    if (noItemsFound) {
-      return Expanded(child: Center(child: configuration.noItemsWidget));
-    }
-    return const SizedBox.shrink();
+    return MultipleLiveDataBuilder.with3<bool, bool, bool>(
+      x1: configuration.viewModel.paginationParams.loading,
+      x2: configuration.viewModel.paginationParams.noItemsFound,
+      x3: configuration.viewModel.paginationParams.error,
+      builder: (context, loading, noItemsFound, error) {
+        if (loading && configuration.viewModel.paginationParams.total == 0 && configuration.viewModel.paginationParams.page == 1) {
+          return configuration.loadingWidget ?? const Center(child: AppProgressBar());
+        }
+        if (error) {
+          return configuration.errorWidget ?? const SizedBox();
+        }
+        if (noItemsFound) {
+          return Center(child: configuration.noItemsWidget);
+        }
+        return const SizedBox();
+      },
+    );
   }
 }

--- a/lib/src/viewmodels/pagination_params.dart
+++ b/lib/src/viewmodels/pagination_params.dart
@@ -1,12 +1,9 @@
 import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 import 'package:flutterx_live_data/flutterx_live_data.dart';
 
-class PaginationParams<T> {
+class PaginationParams<T extends Object> {
   /// check if there is not items after fetch data
   final noItemsFound = MediatorMutableLiveData<bool>(value: false);
-
-  final queryParameters = MediatorMutableLiveData<AbstractQueryParameters>(
-      value: const AbstractQueryParameters());
 
   /// detect if lastPage data is cached data or remote data
   /// send to server new request to fetch new page-list when the lastPage data is not cached
@@ -19,8 +16,7 @@ class PaginationParams<T> {
   int page = 1;
 
   /// displayed items List in UI
-  final MutableLiveData<List<PaginationModel<T>>> itemsList =
-      MutableLiveData(value: List<PaginationModel<T>>.empty(growable: true));
+  final MutableLiveData<List<PaginationModel<T>>> itemsList = MutableLiveData(value: List<PaginationModel<T>>.empty(growable: true));
 
   /// check if user refresh data by `RefreshIndicator`, when true -> reset paginationParams to default value.
   bool isRefresh = false;
@@ -71,8 +67,7 @@ class PaginationParams<T> {
   /// check items after fetched
   void checkFetchedData() {
     final items = itemsList.value.toList();
-    noItemsFound.postValue(
-        items.isEmpty && !loading.value && total == 0 && !idle.value);
+    noItemsFound.postValue(items.isEmpty && !loading.value && total == 0 && !idle.value);
   }
 
   PaginationParams() {

--- a/lib/src/viewmodels/pagination_viewmodel.dart
+++ b/lib/src/viewmodels/pagination_viewmodel.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
-
 import 'package:animated_infinite_scroll_pagination/animated_infinite_scroll_pagination.dart';
 
-mixin PaginationViewModel<T> {
+mixin PaginationViewModel<T extends Object> {
   PaginationParams<T> paginationParams = PaginationParams<T>();
 
   Stream<PaginationState<List<T>>> get state => streamSubscription();
@@ -29,9 +28,7 @@ mixin PaginationViewModel<T> {
 
   /// fetch new items list from your repository
   Future<void> getPaginationList({int? page}) async {
-    if (!paginationParams.loading.value &&
-        !paginationParams.lastPage &&
-        !paginationParams.isCached) {
+    if (!paginationParams.loading.value && !paginationParams.lastPage && !paginationParams.isCached) {
       if (page != null) paginationParams.page = page;
       paginationParams.loading.value = true;
       await fetchData(paginationParams.page);
@@ -48,10 +45,7 @@ mixin PaginationViewModel<T> {
     items.removeWhere((element) => element.page == paginationParams.page);
 
     // mapping list
-    List<PaginationModel<T>> list = data
-        .map((e) => PaginationModel(
-            id: randomString(), item: e, page: paginationParams.page))
-        .toList();
+    List<PaginationModel<T>> list = data.map((e) => PaginationModel(id: randomString(), item: e, page: paginationParams.page)).toList();
 
     // update new list
     final newList = items.isNotEmpty ? (items + list).toList() : list;
@@ -65,8 +59,7 @@ mixin PaginationViewModel<T> {
   /// push new items to start of items-list
   void appendAtFirst(List<T> data) {
     final items = paginationParams.itemsList.value.toList();
-    items.insertAll(0,
-        data.map((e) => PaginationModel(id: randomString(), item: e, page: 1)));
+    items.insertAll(0, data.map((e) => PaginationModel(id: randomString(), item: e, page: 1)));
     paginationParams.itemsList.postValue(items);
   }
 
@@ -90,15 +83,13 @@ mixin PaginationViewModel<T> {
   /// insert new item to list
   void insertItem(int index, T item, int page) {
     final items = paginationParams.itemsList.value.toList();
-    items.insert(
-        index, PaginationModel(id: randomString(), item: item, page: page));
+    items.insert(index, PaginationModel(id: randomString(), item: item, page: page));
     paginationParams.itemsList.postValue(items);
   }
 
   /// empty list
   void clear() {
-    paginationParams.itemsList
-        .postValue(List<PaginationModel<T>>.empty(growable: true));
+    paginationParams.itemsList.postValue(List<PaginationModel<T>>.empty(growable: true));
     setTotal(0);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animated_infinite_scroll_pagination
 description: Flutter package loads and displays small parts of the elements when you scroll down on the screen
-version: 0.3.3
+version: 0.3.5
 homepage: https://github.com/aghiadodeh/animated_infinite_scroll_pagination
 
 


### PR DESCRIPTION
The idea was to constrain the scroll from the parent directly i.e. using a ConstrainedBox or a SizedBox widget. However, I ran into scroll issues indeed. The widget now can be constrained without any issues, by relaying on sliver_tools package.

The usage of SingleChildScrollView will enforce shrink wrap behavior in the child view and that defeat the purpose of refactoring to CustomScrollView.

If you have some missing behavior kindly provide the use case, or if you catch a bug please tell me how to reproduce on my end.